### PR TITLE
doc: add and fix System Error properties

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -455,13 +455,33 @@ a sequence of capital letters, and may be referenced in `man 2 intro`.
 
 #### error.errno
 
-Returns a number corresponding to the **negated** error code, which may be
+Returns a number or a string corresponding to the **negated** error code, which may be
 referenced in `man 2 intro`. For example, an `ENOENT` error has an `errno` of
 `-2` because the error code for `ENOENT` is `2`.
 
 #### error.syscall
 
 Returns a string describing the [syscall][] that failed.
+
+#### error.path
+
+Returns a string of the specified invalid pathname.
+
+#### error.address
+
+Returns a string describing the address that is not available.
+
+#### error.port
+
+Returns a number of the connection's port that is refused (only when the port
+number is specified).
+
+For example:
+
+```js
+require('net').connect({port: 1234}).on('error', (err) => { console.error(err); });
+  // err will have the added properties of code, errno, syscall, address and port
+```
 
 ### Common System Errors
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

In System Errors properties of Errors API, `error.path`, `error.address` and `error.port` are not described although being also represented as augmented Error objects with added properties by the following code.

properties | link
--- | ---
address, port | https://github.com/nodejs/node/blob/v6.x-staging/lib/util.js#L1030-L1051
path | https://github.com/nodejs/node/blob/master/lib/child_process.js#L526

```
// examples
// with `path` property
$node -e "require('fs').readFile('a file that does not exist', (err, data) => { console.error(err); });"
{ Error: ENOENT: no such file or directory, open 'a file that does not exist'
    at Error (native)
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'a file that does not exist' }

// with `address` and `port` property
$node -e "require('net').connect({port: 100}).on('error', (err) => { console.error(err); });"
{ Error: connect ECONNREFUSED 127.0.0.1:100
    at Object.exports._errnoException (util.js:1022:11)
    at exports._exceptionWithHostPort (util.js:1045:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1087:14)
  code: 'ECONNREFUSED',
  errno: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 100 }

// with `address` property (without `port` property)
$node -e "require('net').connect({host: 'localhost'}).on('error', (err) => { console.error(err); });"
{ Error: connect EADDRNOTAVAIL 127.0.0.1 - Local (0.0.0.0:54881)
    at Object.exports._errnoException (util.js:1022:11)
    at exports._exceptionWithHostPort (util.js:1045:20)
    at connect (net.js:881:16)
    at net.js:1010:7
    at GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:62:16)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:81:10)
  code: 'EADDRNOTAVAIL',
  errno: 'EADDRNOTAVAIL',
  syscall: 'connect',
  address: '127.0.0.1' }
```

Also, `error.errno` doesn't always return a number like the above examples.
Please check the following code.

https://github.com/nodejs/node/blob/v6.x-staging/lib/util.js#L1024