### PR TITLE
https: defines maxHeadersCount in the constructor

### DIFF
--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -36,6 +36,13 @@ See [`server.close()`][`http.close()`] from the HTTP module for details.
 Starts the HTTPS server listening for encrypted connections.
 This method is identical to [`server.listen()`][] from [`net.Server`][].
 
+
+### server.maxHeadersCount
+
+- {number} **Default:** `2000`
+
+See [`http.Server#maxHeadersCount`][].
+
 ### server.setTimeout([msecs][, callback])
 <!-- YAML
 added: v0.11.2
@@ -348,6 +355,7 @@ headers: max-age=0; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; p
 [`URL`]: url.html#url_the_whatwg_url_api
 [`http.Agent`]: http.html#http_class_http_agent
 [`http.Server#keepAliveTimeout`]: http.html#http_server_keepalivetimeout
+[`http.Server#maxHeadersCount`]: http.html#http_server_maxheaderscount
 [`http.Server#setTimeout()`]: http.html#http_server_settimeout_msecs_callback
 [`http.Server#timeout`]: http.html#http_server_timeout
 [`http.Server`]: http.html#http_class_http_server

--- a/lib/https.js
+++ b/lib/https.js
@@ -74,6 +74,7 @@ function Server(opts, requestListener) {
 
   this.timeout = 2 * 60 * 1000;
   this.keepAliveTimeout = 5000;
+  this.maxHeadersCount = null;
 }
 inherits(Server, tls.Server);
 

--- a/test/parallel/test-https-max-headers-count.js
+++ b/test/parallel/test-https-max-headers-count.js
@@ -1,0 +1,73 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const https = require('https');
+
+const serverOptions = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+};
+
+let requests = 0;
+let responses = 0;
+
+const headers = {};
+const N = 2000;
+for (let i = 0; i < N; ++i) {
+  headers[`key${i}`] = i;
+}
+
+const maxAndExpected = [ // for server
+  [50, 50],
+  [1500, 1500],
+  [0, N + 2] // Host and Connection
+];
+let max = maxAndExpected[requests][0];
+let expected = maxAndExpected[requests][1];
+
+const server = https.createServer(serverOptions, common.mustCall((req, res) => {
+  assert.strictEqual(Object.keys(req.headers).length, expected);
+  if (++requests < maxAndExpected.length) {
+    max = maxAndExpected[requests][0];
+    expected = maxAndExpected[requests][1];
+    server.maxHeadersCount = max;
+  }
+  res.writeHead(200, headers);
+  res.end();
+}, 3));
+server.maxHeadersCount = max;
+
+server.listen(0, common.mustCall(() => {
+  const maxAndExpected = [ // for client
+    [20, 20],
+    [1200, 1200],
+    [0, N + 3] // Connection, Date and Transfer-Encoding
+  ];
+  const doRequest = common.mustCall(() => {
+    const max = maxAndExpected[responses][0];
+    const expected = maxAndExpected[responses][1];
+    const req = https.request({
+      port: server.address().port,
+      headers: headers,
+      rejectUnauthorized: false
+    }, (res) => {
+      assert.strictEqual(Object.keys(res.headers).length, expected);
+      res.on('end', () => {
+        if (++responses < maxAndExpected.length) {
+          doRequest();
+        } else {
+          server.close();
+        }
+      });
+      res.resume();
+    });
+    req.maxHeadersCount = max;
+    req.end();
+  }, 3);
+  doRequest();
+}));


### PR DESCRIPTION
##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

[In Refs](https://github.com/nodejs/node/pull/9116), http.Server's maxHeadersCount field was defined in the constructor to make hidden class stable and so on.
Also in https.Server,  we can use maxHeadersCount the same as http via connectionListener.
So defines it in the constructor and documentation.

Refs: https://github.com/nodejs/node/pull/9116
