### PR TITLE
doc: add http.ClientRequest maxHeadersCount

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -608,6 +608,12 @@ const setCookie = request.getHeader('set-cookie');
 
 ```
 
+### request.maxHeadersCount
+
+* {number} **Default:** `2000`
+
+Limits maximum response headers count. If set to 0, no limit will be applied.
+
 ### request.removeHeader(name)
 <!-- YAML
 added: v1.6.0
@@ -937,7 +943,7 @@ added: v0.7.0
 
 * {number} **Default:** `2000`
 
-Limits maximum incoming headers count. If set to 0 - no limit will be applied.
+Limits maximum incoming headers count. If set to 0, no limit will be applied.
 
 ### server.setTimeout([msecs][, callback])
 <!-- YAML


### PR DESCRIPTION
In http.ClientRequest's doc, add maxHeadersCount as a public property.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
